### PR TITLE
Add generated report id field management

### DIFF
--- a/src/MarketplaceWebService/Model/ReportRequestInfo.php
+++ b/src/MarketplaceWebService/Model/ReportRequestInfo.php
@@ -69,11 +69,57 @@ class MarketplaceWebService_Model_ReportRequestInfo extends MarketplaceWebServic
         'Scheduled' => array('FieldValue' => null, 'FieldType' => 'bool'),
         'SubmittedDate' => array('FieldValue' => null, 'FieldType' => 'DateTime'),
         'ReportProcessingStatus' => array('FieldValue' => null, 'FieldType' => 'string'),
+        'GeneratedReportId' => array('FieldValue' => null, 'FieldType' => 'string')
         );
         parent::__construct($data);
     }
 
-        /**
+    /**
+     * Gets the value of the GeneratedReportId property.
+     *
+     * @return string GeneratedReportId
+     */
+    public function getGeneratedReportId()
+    {
+        return $this->fields['GeneratedReportId']['FieldValue'];
+    }
+
+    /**
+     * Sets the value of the GeneratedReportId property.
+     *
+     * @param string GeneratedReportId
+     * @return this instance
+     */
+    public function setGeneratedReportId($value)
+    {
+        $this->fields['GeneratedReportId']['FieldValue'] = $value;
+        return $this;
+    }
+
+    /**
+     * Sets the value of the GeneratedReportId and returns this instance
+     *
+     * @param string $value GeneratedReportId
+     * @return MarketplaceWebService_Model_ReportRequestInfo instance
+     */
+    public function withGeneratedReportId($value)
+    {
+        $this->setGeneratedReportId($value);
+        return $this;
+    }
+
+
+    /**
+     * Checks if GeneratedReportId is set
+     *
+     * @return bool true if GeneratedReportId  is set
+     */
+    public function isSetGeneratedReportId()
+    {
+        return !is_null($this->fields['GeneratedReportId']['FieldValue']);
+    }
+
+    /**
      * Gets the value of the ReportRequestId property.
      * 
      * @return string ReportRequestId
@@ -388,8 +434,5 @@ class MarketplaceWebService_Model_ReportRequestInfo extends MarketplaceWebServic
     {
         return !is_null($this->fields['ReportProcessingStatus']['FieldValue']);
     }
-
-
-
 
 }


### PR DESCRIPTION
In order to be able to retrieve generated report from report request id, we need to retrieve report id from report request response.